### PR TITLE
Replace `colorize` with `ansi`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gem "simplecov"
 gem "hirb"
-gem "colorize"
+gem "ansi"
 
 group :development do
   gem "minitest"

--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -1,6 +1,5 @@
-
 require 'hirb'
-require 'colorize'
+require 'ansi/code'
 
 class SimpleCov::Formatter::Console
 
@@ -102,11 +101,11 @@ class SimpleCov::Formatter::Console
     s =~ /([\d.]+)/
     n = $1.to_f
     if n >= 90 then
-      s.colorize(:green)
+      ANSI.green { s }
     elsif n >= 80 then
-      s.colorize(:yellow)
+      ANSI.yellow { s }
     else
-      s.colorize(:red)
+      ANSI.red { s }
     end
   end
 

--- a/simplecov-console.gemspec
+++ b/simplecov-console.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<simplecov>, [">= 0"])
       s.add_runtime_dependency(%q<hirb>, [">= 0"])
-      s.add_runtime_dependency(%q<colorize>, [">= 0"])
+      s.add_runtime_dependency(%q<ansi>, [">= 0"])
       s.add_development_dependency(%q<minitest>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.2"])
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<hirb>, [">= 0"])
-      s.add_dependency(%q<colorize>, [">= 0"])
+      s.add_dependency(%q<ansi>, [">= 0"])
       s.add_dependency(%q<minitest>, [">= 0"])
       s.add_dependency(%q<yard>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.2"])
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<simplecov>, [">= 0"])
     s.add_dependency(%q<hirb>, [">= 0"])
-    s.add_dependency(%q<colorize>, [">= 0"])
+    s.add_dependency(%q<ansi>, [">= 0"])
     s.add_dependency(%q<minitest>, [">= 0"])
     s.add_dependency(%q<yard>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.2"])


### PR DESCRIPTION
I realized that  the colorize gem is distributed under the GPL license and it conflicts the license of this gem. This commit replace the colorize gem with [the ansi gem](https://github.com/rubyworks/ansi), which is distributed under the BSD-2-Clause license.
