### PR TITLE
Fix "shadowing outer local variable" warning

### DIFF
--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -89,11 +89,11 @@ class SimpleCov::Formatter::Console
     end
 
     group_str = []
-    groups.map do |base, v|
-      if v > 0
-        group_str << "#{base}-#{base + v}"
+    groups.map do |starting_line, length|
+      if length > 0
+        group_str << "#{starting_line}-#{starting_line + length}"
       else
-        group_str << "#{base}"
+        group_str << "#{starting_line}"
       end
     end
 


### PR DESCRIPTION
Hi there,

I was working on a project today and I got this warning from simplecov-console:

    lib/simplecov-console.rb:92: warning: shadowing outer local variable - base

Here's a quick fix for that. This doesn't change any functionality, and the code is already covered by existing tests in `test_simplecov-console.rb`.

Thanks!