### PR TITLE
Feature/customize table size

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Simply export `NO_COLOR=1` and colors will be disabled.
 NO_COLOR=1 rake test
 ```
 
+### Maximum Rows Displayed
+
+By default, a maximum of 15 files with the worst coverage are displayed in the report.  You can override this limit by setting the `MAX_ROWS` environment variable, or setting `SimpleCov::Formatter::Console.max_rows = (number)` in your test helper.  Setting a value of `-1` or `nil` will show all of the files.
+
 ### Table options
 
 In some cases, you may need to pass some options to `TerminalTable.new`. For example, if the filenames are

--- a/README.md
+++ b/README.md
@@ -54,9 +54,31 @@ Simply export `NO_COLOR=1` and colors will be disabled.
 NO_COLOR=1 rake test
 ```
 
-### Maximum Rows Displayed
+### Sorting the output
 
-By default, a maximum of 15 files with the worst coverage are displayed in the report.  You can override this limit by setting the `MAX_ROWS` environment variable, or setting `SimpleCov::Formatter::Console.max_rows = (number)` in your test helper.  Setting a value of `-1` or `nil` will show all of the files.
+By default the coverage report is sorted by coverage % in descending order.  To sort alphabetically by path, set the `SORT` environment variable to "path", or add the following to your test helper:
+
+```ruby
+SimpleCov::Formatter::Console.sort = 'path' # sort by file path
+```
+
+### Showing covered files
+
+By default, fully covered files are excluded from the report.  To show them, set the `SHOW_COVERED` environment variable to `true` or add the following to your test helper:
+
+```ruby
+SimpleCov::Formatter::Console.show_covered = true # show all files in coverage report
+```
+
+### Maximum rows displayed
+
+By default, a maximum of 15 files with the worst coverage are displayed in the report.  You can override this limit by setting the `MAX_ROWS` environment variable, or adding the following to your test helper:
+
+```ruby
+SimpleCov::Formatter::Console.max_rows = # some number
+```
+ 
+ Setting a value of `-1` or `nil` will show all of the files.
 
 ### Table options
 

--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -14,6 +14,9 @@ class SimpleCov::Formatter::Console
   SimpleCov::Formatter::Console.use_colors =
     (ENV['NO_COLOR'].nil? or ENV['NO_COLOR'].empty?) ? true : false
 
+  # configure max rows from MAX_ROWS env var
+  SimpleCov::Formatter::Console.max_rows = ENV.fetch('MAX_ROWS', 15)
+
   def format(result)
 
     root = nil
@@ -61,9 +64,9 @@ class SimpleCov::Formatter::Console
       ]
     end
 
-    max_rows = SimpleCov::Formatter::Console.fetch(:max_rows, 15)
+    max_rows = SimpleCov::Formatter::Console.max_rows
 
-    if table.size > max_rows && max_rows != -1 then
+    if ![-1, nil].include?(max_rows) && table.size > max_rows then
       puts "showing bottom (worst) #{max_rows} of #{table.size} files"
       table = table.slice(0, max_rows)
     end

--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -5,7 +5,7 @@ class SimpleCov::Formatter::Console
 
   VERSION = IO.read(File.expand_path("../../VERSION", __FILE__)).strip
 
-  ATTRIBUTES = [:table_options, :use_colors]
+  ATTRIBUTES = [:table_options, :use_colors, :max_rows]
   class << self
     attr_accessor(*ATTRIBUTES)
   end
@@ -61,9 +61,11 @@ class SimpleCov::Formatter::Console
       ]
     end
 
-    if table.size > 15 then
-      puts "showing bottom (worst) 15 of #{table.size} files"
-      table = table.slice(0, 15)
+    max_rows = SimpleCov::Formatter::Console.fetch(:max_rows, 15)
+
+    if table.size > max_rows && max_rows != -1 then
+      puts "showing bottom (worst) #{max_rows} of #{table.size} files"
+      table = table.slice(0, max_rows)
     end
 
     table_options = SimpleCov::Formatter::Console.table_options || {}


### PR DESCRIPTION
- Adds MAX_ROWS environment variable to allow users to override the 15 row limit
- You can also set this directly using `SimpleCov::Formatter::Console.max_rows = (some number)`
- Values of `nil` or `-1` will remove the row limit completely
- Adds `SORT` to control the sorting of files by coverage (the default) or path
- Adds `SHOW_COVERED` option to show all covered files in the report.