### PR TITLE
Update usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ $ gem install simplecov-console
 ```ruby
 SimpleCov.formatter = SimpleCov::Formatter::Console
 # or
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::Console,
-]
+])
 ```
 
 Example output:


### PR DESCRIPTION
Calling `SimpleCov::Formatter::MultiFormatter[...]` causes Simplecov to [print a deprecation warning][1].

This commit changes the call in the usage example to `SimpleCov::Formatter::MultiFormatter.new([...])`.

[1]: https://github.com/colszowka/simplecov/blob/master/lib/simplecov/formatter/multi_formatter.rb#L29