### PR TITLE
Plain-text block output style option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,46 @@ SimpleCov::Formatter::Console.table_options = {:style => {:width => 200}}
 SimpleCov.formatter = SimpleCov::Formatter::Console
 ```
 
+### Block output style
+
+As an alternative to the default table output format, results can be printed as plain text blocks instead by setting 
+the formatter `output_style` to 'block':
+
+```ruby
+SimpleCov::Formatter::Console.output_style = 'block'
+SimpleCov.formatter = SimpleCov::Formatter::Console
+```
+
+Example output:
+
+```text
+COVERAGE:  82.34% -- 2345/2848 lines in 111 files
+
+showing bottom (worst) 5 of 69 files
+
+    file: lib/bixby/api/websocket_server.rb
+coverage: 22.73% (17/22 lines)
+  missed: 11, 14, 17-18, 20-22, 24, 28-30, 32, 36-...
+
+    file: app/models/role.rb
+coverage: 30.77% (9/13 lines)
+  missed: 28-34, 36-37
+
+    file: lib/bixby/modules/metrics/rescan.rb
+coverage: 32.14% (19/28 lines)
+  missed: 19-23, 27-31, 33-37, 39-41, 43
+
+    file: lib/archie/mail.rb
+coverage: 42.86% (8/14 lines)
+  missed: 6-8, 12-15, 22
+
+    file: lib/archie/controller.rb
+coverage: 44.00% (28/50 lines)
+  missed: 18-21, 23, 27-30, 32, 38-40, 44-45, 48-4...
+
+42 file(s) with 100% coverage not shown
+```
+
 ## History
 
 ### 0.6 (2019.11.08)

--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -169,7 +169,7 @@ class SimpleCov::Formatter::Console
       block << sprintf("%8.8s: %s", 'missed', missed(f.missed_lines).join(", "))
       blocks << block.join("\n")
     end
-    "\n" << blocks.join("\n\n") << "\n"
+    "\n" << blocks.join("\n\n") << "\n\n"
   end
 
 end

--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -76,7 +76,7 @@ class SimpleCov::Formatter::Console
       files = files.slice(0, max_rows)
     end
 
-    send(SimpleCov::Formatter::Console.output_style << "_output",files,root)
+    puts send(SimpleCov::Formatter::Console.output_style << "_output",files,root)
     
     if covered_files > 0 then
       puts "#{covered_files} file(s) with 100% coverage not shown"
@@ -134,6 +134,7 @@ class SimpleCov::Formatter::Console
     end
   end
 
+  # format per-file results output using Terminal::Table
   def table_output(files, root)
     table = files.map do |f|
       [
@@ -153,20 +154,22 @@ class SimpleCov::Formatter::Console
     headings = %w{ coverage file lines missed missing }
 
     opts = table_options.merge({:headings => headings, :rows => table})
-    t = Terminal::Table.new(opts)
-    puts t
+    Terminal::Table.new(opts)
   end
 
+  # format per-file results output as plain text blocks
   def block_output(files, root)
-    puts ""
+    blocks = [""]
     files.each do |f|
-      puts sprintf("%8.8s: %s", 'file', f.filename.gsub(root + "/", ''))
-      puts sprintf("%8.8s: %s (%d/%d lines)", 'coverage', 
+      block = []
+      block << sprintf("%8.8s: %s", 'file', f.filename.gsub(root + "/", ''))
+      block << sprintf("%8.8s: %s (%d/%d lines)", 'coverage', 
                    colorize(sprintf("%.2f%%", f.covered_percent)), 
                    f.covered_lines.count, f.lines_of_code)
-      puts sprintf("%8.8s: %s", 'missed', missed(f.missed_lines).join(", "))
-      puts ""
+      block << sprintf("%8.8s: %s", 'missed', missed(f.missed_lines).join(", "))
+      blocks << block.join("\n")
     end
+    blocks.join("\n") 
   end
 
 end

--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -159,7 +159,7 @@ class SimpleCov::Formatter::Console
 
   # format per-file results output as plain text blocks
   def block_output(files, root)
-    blocks = [""]
+    blocks = []
     files.each do |f|
       block = []
       block << sprintf("%8.8s: %s", 'file', f.filename.gsub(root + "/", ''))
@@ -169,7 +169,7 @@ class SimpleCov::Formatter::Console
       block << sprintf("%8.8s: %s", 'missed', missed(f.missed_lines).join(", "))
       blocks << block.join("\n")
     end
-    blocks.join("\n") 
+    "\n" << blocks.join("\n\n") << "\n"
   end
 
 end

--- a/test/test_simplecov-console.rb
+++ b/test/test_simplecov-console.rb
@@ -2,7 +2,17 @@ require 'helper'
 
 class TestSimplecovConsole < MiniTest::Test
 
-  Source = Struct.new(:line_number)
+  # mock for SimpleCov::SourceFile::Line
+  Line = Struct.new(:line_number)
+
+  # mock for SimpleCov::SourceFile
+  SourceFile = Struct.new(
+    :filename,
+    :lines_of_code,
+    :covered_lines,
+    :missed_lines,
+    :covered_percent
+  )
 
   def setup
     @console = SimpleCov::Formatter::Console.new
@@ -14,9 +24,29 @@ class TestSimplecovConsole < MiniTest::Test
   end
 
   def test_missed
-    missed_lines = [Source.new(1), Source.new(2),
-                    Source.new(3), Source.new(5)]
+    missed_lines = [Line.new(1), Line.new(2),
+                    Line.new(3), Line.new(5)]
     expected_result = ["1-3", "5"]
     assert_equal @console.missed(missed_lines), expected_result
+  end
+
+  def test_table_output
+    SimpleCov::Formatter::Console.output_style = 'table'
+    files = [
+      SourceFile.new('foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0)
+    ]
+    actual = @console.table_output(files,'/')
+    assert actual.is_a? Terminal::Table
+    assert_equal 1, actual.rows.count 
+  end
+
+  def test_block_output
+    SimpleCov::Formatter::Console.use_colors = false
+    SimpleCov::Formatter::Console.output_style = 'block'
+    files = [
+      SourceFile.new('foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0)
+    ]
+    expected = "\n    file: foo.rb\ncoverage: 40.00% (2/5 lines)\n  missed: 1, 4-5"
+    assert_equal expected, @console.block_output(files,'/')
   end
 end

--- a/test/test_simplecov-console.rb
+++ b/test/test_simplecov-console.rb
@@ -46,7 +46,7 @@ class TestSimplecovConsole < MiniTest::Test
     files = [
       SourceFile.new('foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0)
     ]
-    expected = "\n    file: foo.rb\ncoverage: 40.00% (2/5 lines)\n  missed: 1, 4-5"
+    expected = "\n    file: foo.rb\ncoverage: 40.00% (2/5 lines)\n  missed: 1, 4-5\n\n"
     assert_equal expected, @console.block_output(files,'/')
   end
 end


### PR DESCRIPTION
Adds a new `output_style` configuration option that allows for the results to be printed using either the default `Terminal::Table` utility or as plain text blocks.  

I wanted something similar to what you get with the extended output option in psql/mysql clients, for better readability of the results when running on a CI host or in a narrow terminal window.  So this just moves the detailed file-specific output logic into separate generator methods, one for the default table style and one for the new 'block' style.  Includes test + README updates.