### PR TITLE
Add branch coverage output

### DIFF
--- a/lib/simplecov-console/output/block.rb
+++ b/lib/simplecov-console/output/block.rb
@@ -3,7 +3,7 @@ class SimpleCov::Formatter::Console
   module BlockOutput
 
     # format per-file results output as plain text blocks
-    def output(files, root)
+    def output(files, root, show_branch)
       blocks = []
       files.each do |f|
         block = []
@@ -12,6 +12,12 @@ class SimpleCov::Formatter::Console
                     colorize(sprintf("%.2f%%", f.covered_percent)),
                     f.covered_lines.count, f.lines_of_code)
         block << sprintf("%8.8s: %s", 'missed', missed(f.missed_lines).join(", "))
+        if show_branch
+          block << sprintf("%8.8s: %s (%d/%d branches)", 'branches',
+                    colorize(sprintf("%.2f%%", f.coverage_statistics[:branch].percent)),
+                    (f.total_branches.count - f.missed_branches.count), f.total_branches.count)
+          block << sprintf("%8.8s: %s", 'missed', branches_missed(f.missed_branches).join(", "))
+        end
         blocks << block.join("\n")
       end
 

--- a/lib/simplecov-console/output/table.rb
+++ b/lib/simplecov-console/output/table.rb
@@ -4,15 +4,25 @@ class SimpleCov::Formatter::Console
   module TableOutput
 
     # format per-file results output using Terminal::Table
-    def output(files, root)
+    def output(files, root,show_branch)
       table = files.map do |f|
-        [
-          colorize(pct(f)),
+        row = [
+          colorize(pct(f.covered_percent)),
           f.filename.gsub(root + "/", ''),
           f.lines_of_code,
           f.missed_lines.count,
-          missed(f.missed_lines).join(", ")
+          missed(f.missed_lines).join(", "),
         ]
+        if show_branch
+          row += [
+            colorize(pct(f.coverage_statistics[:branch].percent)),
+            f.total_branches.count,
+            f.missed_branches.count,
+            branches_missed(f.missed_branches).join(", ")
+          ]
+        end
+
+        row
       end
 
       table_options = SimpleCov::Formatter::Console.table_options || {}
@@ -21,6 +31,14 @@ class SimpleCov::Formatter::Console
       end
 
       headings = %w{ coverage file lines missed missing }
+      if show_branch
+        headings += [
+          'branch coverage',
+          'branches',
+          'branches missed',
+          'branches missing'
+        ]
+      end
 
       opts = table_options.merge({:headings => headings, :rows => table})
       Terminal::Table.new(opts)

--- a/test/test_simplecov-console.rb
+++ b/test/test_simplecov-console.rb
@@ -14,6 +14,24 @@ class TestSimplecovConsole < MiniTest::Test
     :covered_percent
   )
 
+  CoverageStatistics = Struct.new(
+    :percent
+  )
+  Branch = Struct.new(
+    :start_line,
+    :type
+  )
+  SourceFileWithBranches = Struct.new(
+    :filename,
+    :lines_of_code,
+    :covered_lines,
+    :missed_lines,
+    :covered_percent,
+    :coverage_statistics,
+    :total_branches,
+    :missed_branches
+  )
+
   def setup
     @console = SimpleCov::Formatter::Console.new
   end
@@ -40,7 +58,22 @@ class TestSimplecovConsole < MiniTest::Test
     files = [
       SourceFile.new('foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0)
     ]
-    actual = @console.output(files,'/')
+    actual = @console.output(files,'/',false)
+    assert actual.is_a? Terminal::Table
+    assert_equal 1, actual.rows.count
+  end
+
+  def test_table_output_with_branches
+    SimpleCov::Formatter::Console.output_style = 'table'
+    @console.include_output_style
+    files = [
+      SourceFileWithBranches.new(
+        'foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0,
+        {branch: CoverageStatistics.new(50.0)}, [1,2],
+        [Branch.new(2, :then)]
+      )
+    ]
+    actual = @console.output(files,'/',true)
     assert actual.is_a? Terminal::Table
     assert_equal 1, actual.rows.count
   end
@@ -54,6 +87,21 @@ class TestSimplecovConsole < MiniTest::Test
       SourceFile.new('foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0)
     ]
     expected = "\n    file: foo.rb\ncoverage: 40.00% (2/5 lines)\n  missed: 1, 4-5\n\n"
-    assert_equal expected, @console.output(files,'/')
+    assert_equal expected, @console.output(files,'/',false)
+  end
+
+  def test_block_output_with_branches
+    SimpleCov::Formatter::Console.use_colors = false
+    SimpleCov::Formatter::Console.output_style = 'block'
+    @console.include_output_style
+    files = [
+      SourceFileWithBranches.new(
+        'foo.rb',5,[2,3],[Line.new(1), Line.new(4), Line.new(5)],40.0,
+        {branch: CoverageStatistics.new(50.0)}, [1,2],
+        [Branch.new(2, :then)]
+      )
+    ]
+    expected = "\n    file: foo.rb\ncoverage: 40.00% (2/5 lines)\n  missed: 1, 4-5\nbranches: 50% (1/2 branches)\n  missed: 2[then]\n\n"
+    assert_equal expected, @console.output(files,'/',true)
   end
 end


### PR DESCRIPTION
This will only show if simplecov is recording branch coverage, otherwise
the output is unchanged

The output does look kinda awkward and busy, but all i care about is
actually being able to see output from CI without having to set up some
kind of artifact hosting for the coverage/index.html

fixes: #18

example output:

Passing:
```
COVERAGE: 100.00% -- 1743/1743 lines in 108 files
BRANCH COVERAGE: 100.00% -- 434/434 branches in 108 branches
```

Failing (block format):
```
COVERAGE: 100.00% -- 1743/1743 lines in 108 files
BRANCH COVERAGE:  99.77% -- 434/435 branches in 108 branches

    file: lib/leftovers/config_validator/error_processor.rb
coverage: 100.00% (96/96 lines)
  missed:
branches: 96.97% (32/33 branches)
  missed: 112[else]
```

Failing (table format):
```
COVERAGE: 100.00% -- 1743/1743 lines in 108 files
BRANCH COVERAGE:  99.77% -- 434/435 branches in 108 branches

+----------+---------------------------------------------------+-------+--------+---------+-----------------+----------+-----------------+------------------+
| coverage | file                                              | lines | missed | missing | branch coverage | branches | branches missed | branches missing |
+----------+---------------------------------------------------+-------+--------+---------+-----------------+----------+-----------------+------------------+
| 100.00%  | lib/leftovers/config_validator/error_processor.rb | 96    | 0      |         |  96.97%         | 33       | 1               | 112[else]        |
+----------+---------------------------------------------------+-------+--------+---------+-----------------+----------+-----------------+------------------+
```