### PR TITLE
Don't add elipses if line groups have not been truncated

### DIFF
--- a/lib/simplecov-console.rb
+++ b/lib/simplecov-console.rb
@@ -153,8 +153,9 @@ class SimpleCov::Formatter::Console
       end
     end
 
-    if SimpleCov::Formatter::Console.max_lines > 0 then
-      # show at most N missing groups of lines
+    max_lines = SimpleCov::Formatter::Console.max_lines
+    if max_lines > 0 && group_str.size > max_lines then
+      # Show at most N missing groups of lines
       group_str = group_str[0, SimpleCov::Formatter::Console.max_lines] << "..."
     end
 

--- a/test/test_simplecov-console.rb
+++ b/test/test_simplecov-console.rb
@@ -61,6 +61,10 @@ class TestSimplecovConsole < MiniTest::Test
                     Line.new(3), Line.new(5)]
     expected_result = ["1-3", "..."]
     assert_equal expected_result, @console.missed(missed_lines)
+
+    SimpleCov::Formatter::Console.max_lines = 3
+    expected_result = ["1-3", "5"]
+    assert_equal expected_result, @console.missed(missed_lines)
   end
 
   def test_table_output


### PR DESCRIPTION
I noticed the ... was being added even when there were not too many lines being shown for that file: 
![image](https://user-images.githubusercontent.com/294776/106212362-6e657c00-6198-11eb-9c99-7e6b8d699bd6.png)

Added a failing test and then a quick fix.